### PR TITLE
Migrate data source from rules.json to messages.yaml

### DIFF
--- a/tools/update_lint_rules/lib/src/models/lint_rule.dart
+++ b/tools/update_lint_rules/lib/src/models/lint_rule.dart
@@ -2,7 +2,6 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 part 'lint_rule.freezed.dart';
-
 part 'lint_rule.g.dart';
 
 typedef LintRules = ({
@@ -21,14 +20,9 @@ sealed class LintRule with _$LintRule {
 class Rule with _$Rule {
   const factory Rule({
     required String name,
-    required String description,
-    required List<String> categories,
-    required RuleState state,
-    @JsonKey(name: 'incompatible') required List<String> incompatibles,
-    required List<RuleSet> sets,
-    required FixStatus fixStatus,
-    required String details,
-    @JsonKey(name: 'sinceDartSdk') required Since since,
+    required List<String>? categories,
+    @JsonKey(name: 'deprecatedDetails') required String? details,
+    @_StateJsonConverter() required State? state,
   }) = _Rule;
 
   factory Rule.fromJson(Map<String, dynamic> json) => _$RuleFromJson(json);
@@ -41,6 +35,14 @@ enum RuleState {
   experimental,
   deprecated,
   removed,
+  internal;
+
+  bool get active => switch (this) {
+        RuleState.stable || RuleState.experimental => true,
+        RuleState.deprecated || RuleState.removed || RuleState.internal => false
+      };
+
+  bool get inactive => !active;
 }
 
 enum RuleSet {
@@ -98,4 +100,20 @@ sealed class Since with _$Since {
           '${version.major}.${version.minor}',
         SinceUnreleased() => 'unreleased',
       };
+}
+
+typedef State = Map<RuleState, Since>;
+
+class _StateJsonConverter
+    implements JsonConverter<State, Map<String, dynamic>> {
+  const _StateJsonConverter();
+
+  @override
+  State fromJson(Map<String, dynamic> value) {
+    return value.map((key, value) =>
+        MapEntry(RuleState.values.byName(key), Since.fromJson(value)));
+  }
+
+  @override
+  Map<String, dynamic> toJson(State value) => Map<String, dynamic>.from(value);
 }

--- a/tools/update_lint_rules/lib/src/models/lint_rule.freezed.dart
+++ b/tools/update_lint_rules/lib/src/models/lint_rule.freezed.dart
@@ -390,16 +390,11 @@ Rule _$RuleFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$Rule {
   String get name => throw _privateConstructorUsedError;
-  String get description => throw _privateConstructorUsedError;
-  List<String> get categories => throw _privateConstructorUsedError;
-  RuleState get state => throw _privateConstructorUsedError;
-  @JsonKey(name: 'incompatible')
-  List<String> get incompatibles => throw _privateConstructorUsedError;
-  List<RuleSet> get sets => throw _privateConstructorUsedError;
-  FixStatus get fixStatus => throw _privateConstructorUsedError;
-  String get details => throw _privateConstructorUsedError;
-  @JsonKey(name: 'sinceDartSdk')
-  Since get since => throw _privateConstructorUsedError;
+  List<String>? get categories => throw _privateConstructorUsedError;
+  @JsonKey(name: 'deprecatedDetails')
+  String? get details => throw _privateConstructorUsedError;
+  @_StateJsonConverter()
+  Map<RuleState, Since>? get state => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -413,16 +408,9 @@ abstract class $RuleCopyWith<$Res> {
   @useResult
   $Res call(
       {String name,
-      String description,
-      List<String> categories,
-      RuleState state,
-      @JsonKey(name: 'incompatible') List<String> incompatibles,
-      List<RuleSet> sets,
-      FixStatus fixStatus,
-      String details,
-      @JsonKey(name: 'sinceDartSdk') Since since});
-
-  $SinceCopyWith<$Res> get since;
+      List<String>? categories,
+      @JsonKey(name: 'deprecatedDetails') String? details,
+      @_StateJsonConverter() Map<RuleState, Since>? state});
 }
 
 /// @nodoc
@@ -439,61 +427,28 @@ class _$RuleCopyWithImpl<$Res, $Val extends Rule>
   @override
   $Res call({
     Object? name = null,
-    Object? description = null,
-    Object? categories = null,
-    Object? state = null,
-    Object? incompatibles = null,
-    Object? sets = null,
-    Object? fixStatus = null,
-    Object? details = null,
-    Object? since = null,
+    Object? categories = freezed,
+    Object? details = freezed,
+    Object? state = freezed,
   }) {
     return _then(_value.copyWith(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      description: null == description
-          ? _value.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String,
-      categories: null == categories
+      categories: freezed == categories
           ? _value.categories
           : categories // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      state: null == state
-          ? _value.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as RuleState,
-      incompatibles: null == incompatibles
-          ? _value.incompatibles
-          : incompatibles // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      sets: null == sets
-          ? _value.sets
-          : sets // ignore: cast_nullable_to_non_nullable
-              as List<RuleSet>,
-      fixStatus: null == fixStatus
-          ? _value.fixStatus
-          : fixStatus // ignore: cast_nullable_to_non_nullable
-              as FixStatus,
-      details: null == details
+              as List<String>?,
+      details: freezed == details
           ? _value.details
           : details // ignore: cast_nullable_to_non_nullable
-              as String,
-      since: null == since
-          ? _value.since
-          : since // ignore: cast_nullable_to_non_nullable
-              as Since,
+              as String?,
+      state: freezed == state
+          ? _value.state
+          : state // ignore: cast_nullable_to_non_nullable
+              as Map<RuleState, Since>?,
     ) as $Val);
-  }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $SinceCopyWith<$Res> get since {
-    return $SinceCopyWith<$Res>(_value.since, (value) {
-      return _then(_value.copyWith(since: value) as $Val);
-    });
   }
 }
 
@@ -505,17 +460,9 @@ abstract class _$$_RuleCopyWith<$Res> implements $RuleCopyWith<$Res> {
   @useResult
   $Res call(
       {String name,
-      String description,
-      List<String> categories,
-      RuleState state,
-      @JsonKey(name: 'incompatible') List<String> incompatibles,
-      List<RuleSet> sets,
-      FixStatus fixStatus,
-      String details,
-      @JsonKey(name: 'sinceDartSdk') Since since});
-
-  @override
-  $SinceCopyWith<$Res> get since;
+      List<String>? categories,
+      @JsonKey(name: 'deprecatedDetails') String? details,
+      @_StateJsonConverter() Map<RuleState, Since>? state});
 }
 
 /// @nodoc
@@ -528,52 +475,27 @@ class __$$_RuleCopyWithImpl<$Res> extends _$RuleCopyWithImpl<$Res, _$_Rule>
   @override
   $Res call({
     Object? name = null,
-    Object? description = null,
-    Object? categories = null,
-    Object? state = null,
-    Object? incompatibles = null,
-    Object? sets = null,
-    Object? fixStatus = null,
-    Object? details = null,
-    Object? since = null,
+    Object? categories = freezed,
+    Object? details = freezed,
+    Object? state = freezed,
   }) {
     return _then(_$_Rule(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      description: null == description
-          ? _value.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String,
-      categories: null == categories
+      categories: freezed == categories
           ? _value._categories
           : categories // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      state: null == state
-          ? _value.state
-          : state // ignore: cast_nullable_to_non_nullable
-              as RuleState,
-      incompatibles: null == incompatibles
-          ? _value._incompatibles
-          : incompatibles // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      sets: null == sets
-          ? _value._sets
-          : sets // ignore: cast_nullable_to_non_nullable
-              as List<RuleSet>,
-      fixStatus: null == fixStatus
-          ? _value.fixStatus
-          : fixStatus // ignore: cast_nullable_to_non_nullable
-              as FixStatus,
-      details: null == details
+              as List<String>?,
+      details: freezed == details
           ? _value.details
           : details // ignore: cast_nullable_to_non_nullable
-              as String,
-      since: null == since
-          ? _value.since
-          : since // ignore: cast_nullable_to_non_nullable
-              as Since,
+              as String?,
+      state: freezed == state
+          ? _value._state
+          : state // ignore: cast_nullable_to_non_nullable
+              as Map<RuleState, Since>?,
     ));
   }
 }
@@ -583,63 +505,44 @@ class __$$_RuleCopyWithImpl<$Res> extends _$RuleCopyWithImpl<$Res, _$_Rule>
 class _$_Rule extends _Rule {
   const _$_Rule(
       {required this.name,
-      required this.description,
-      required final List<String> categories,
-      required this.state,
-      @JsonKey(name: 'incompatible') required final List<String> incompatibles,
-      required final List<RuleSet> sets,
-      required this.fixStatus,
-      required this.details,
-      @JsonKey(name: 'sinceDartSdk') required this.since})
+      required final List<String>? categories,
+      @JsonKey(name: 'deprecatedDetails') required this.details,
+      @_StateJsonConverter() required final Map<RuleState, Since>? state})
       : _categories = categories,
-        _incompatibles = incompatibles,
-        _sets = sets,
+        _state = state,
         super._();
 
   factory _$_Rule.fromJson(Map<String, dynamic> json) => _$$_RuleFromJson(json);
 
   @override
   final String name;
+  final List<String>? _categories;
   @override
-  final String description;
-  final List<String> _categories;
-  @override
-  List<String> get categories {
+  List<String>? get categories {
+    final value = _categories;
+    if (value == null) return null;
     if (_categories is EqualUnmodifiableListView) return _categories;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_categories);
+    return EqualUnmodifiableListView(value);
   }
 
   @override
-  final RuleState state;
-  final List<String> _incompatibles;
+  @JsonKey(name: 'deprecatedDetails')
+  final String? details;
+  final Map<RuleState, Since>? _state;
   @override
-  @JsonKey(name: 'incompatible')
-  List<String> get incompatibles {
-    if (_incompatibles is EqualUnmodifiableListView) return _incompatibles;
+  @_StateJsonConverter()
+  Map<RuleState, Since>? get state {
+    final value = _state;
+    if (value == null) return null;
+    if (_state is EqualUnmodifiableMapView) return _state;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_incompatibles);
+    return EqualUnmodifiableMapView(value);
   }
-
-  final List<RuleSet> _sets;
-  @override
-  List<RuleSet> get sets {
-    if (_sets is EqualUnmodifiableListView) return _sets;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_sets);
-  }
-
-  @override
-  final FixStatus fixStatus;
-  @override
-  final String details;
-  @override
-  @JsonKey(name: 'sinceDartSdk')
-  final Since since;
 
   @override
   String toString() {
-    return 'Rule(name: $name, description: $description, categories: $categories, state: $state, incompatibles: $incompatibles, sets: $sets, fixStatus: $fixStatus, details: $details, since: $since)';
+    return 'Rule(name: $name, categories: $categories, details: $details, state: $state)';
   }
 
   @override
@@ -648,18 +551,10 @@ class _$_Rule extends _Rule {
         (other.runtimeType == runtimeType &&
             other is _$_Rule &&
             (identical(other.name, name) || other.name == name) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
             const DeepCollectionEquality()
                 .equals(other._categories, _categories) &&
-            (identical(other.state, state) || other.state == state) &&
-            const DeepCollectionEquality()
-                .equals(other._incompatibles, _incompatibles) &&
-            const DeepCollectionEquality().equals(other._sets, _sets) &&
-            (identical(other.fixStatus, fixStatus) ||
-                other.fixStatus == fixStatus) &&
             (identical(other.details, details) || other.details == details) &&
-            (identical(other.since, since) || other.since == since));
+            const DeepCollectionEquality().equals(other._state, _state));
   }
 
   @JsonKey(ignore: true)
@@ -667,14 +562,9 @@ class _$_Rule extends _Rule {
   int get hashCode => Object.hash(
       runtimeType,
       name,
-      description,
       const DeepCollectionEquality().hash(_categories),
-      state,
-      const DeepCollectionEquality().hash(_incompatibles),
-      const DeepCollectionEquality().hash(_sets),
-      fixStatus,
       details,
-      since);
+      const DeepCollectionEquality().hash(_state));
 
   @JsonKey(ignore: true)
   @override
@@ -692,15 +582,11 @@ class _$_Rule extends _Rule {
 
 abstract class _Rule extends Rule {
   const factory _Rule(
-      {required final String name,
-      required final String description,
-      required final List<String> categories,
-      required final RuleState state,
-      @JsonKey(name: 'incompatible') required final List<String> incompatibles,
-      required final List<RuleSet> sets,
-      required final FixStatus fixStatus,
-      required final String details,
-      @JsonKey(name: 'sinceDartSdk') required final Since since}) = _$_Rule;
+          {required final String name,
+          required final List<String>? categories,
+          @JsonKey(name: 'deprecatedDetails') required final String? details,
+          @_StateJsonConverter() required final Map<RuleState, Since>? state}) =
+      _$_Rule;
   const _Rule._() : super._();
 
   factory _Rule.fromJson(Map<String, dynamic> json) = _$_Rule.fromJson;
@@ -708,23 +594,13 @@ abstract class _Rule extends Rule {
   @override
   String get name;
   @override
-  String get description;
+  List<String>? get categories;
   @override
-  List<String> get categories;
+  @JsonKey(name: 'deprecatedDetails')
+  String? get details;
   @override
-  RuleState get state;
-  @override
-  @JsonKey(name: 'incompatible')
-  List<String> get incompatibles;
-  @override
-  List<RuleSet> get sets;
-  @override
-  FixStatus get fixStatus;
-  @override
-  String get details;
-  @override
-  @JsonKey(name: 'sinceDartSdk')
-  Since get since;
+  @_StateJsonConverter()
+  Map<RuleState, Since>? get state;
   @override
   @JsonKey(ignore: true)
   _$$_RuleCopyWith<_$_Rule> get copyWith => throw _privateConstructorUsedError;

--- a/tools/update_lint_rules/lib/src/models/lint_rule.g.dart
+++ b/tools/update_lint_rules/lib/src/models/lint_rule.g.dart
@@ -14,61 +14,37 @@ _$_Rule _$$_RuleFromJson(Map<String, dynamic> json) => $checkedCreate(
       ($checkedConvert) {
         final val = _$_Rule(
           name: $checkedConvert('name', (v) => v as String),
-          description: $checkedConvert('description', (v) => v as String),
           categories: $checkedConvert('categories',
-              (v) => (v as List<dynamic>).map((e) => e as String).toList()),
+              (v) => (v as List<dynamic>?)?.map((e) => e as String).toList()),
+          details: $checkedConvert('deprecatedDetails', (v) => v as String?),
           state: $checkedConvert(
-              'state', (v) => $enumDecode(_$RuleStateEnumMap, v)),
-          incompatibles: $checkedConvert('incompatible',
-              (v) => (v as List<dynamic>).map((e) => e as String).toList()),
-          sets: $checkedConvert(
-              'sets',
-              (v) => (v as List<dynamic>)
-                  .map((e) => $enumDecode(_$RuleSetEnumMap, e))
-                  .toList()),
-          fixStatus: $checkedConvert(
-              'fixStatus', (v) => $enumDecode(_$FixStatusEnumMap, v)),
-          details: $checkedConvert('details', (v) => v as String),
-          since: $checkedConvert(
-              'sinceDartSdk', (v) => Since.fromJson(v as String)),
+              'state',
+              (v) => _$JsonConverterFromJson<Map<String, dynamic>,
+                      Map<RuleState, Since>>(
+                  v, const _StateJsonConverter().fromJson)),
         );
         return val;
       },
-      fieldKeyMap: const {
-        'incompatibles': 'incompatible',
-        'since': 'sinceDartSdk'
-      },
+      fieldKeyMap: const {'details': 'deprecatedDetails'},
     );
 
 Map<String, dynamic> _$$_RuleToJson(_$_Rule instance) => <String, dynamic>{
       'name': instance.name,
-      'description': instance.description,
       'categories': instance.categories,
-      'state': _$RuleStateEnumMap[instance.state]!,
-      'incompatible': instance.incompatibles,
-      'sets': instance.sets.map((e) => _$RuleSetEnumMap[e]!).toList(),
-      'fixStatus': _$FixStatusEnumMap[instance.fixStatus]!,
-      'details': instance.details,
-      'sinceDartSdk': instance.since.toJson(),
+      'deprecatedDetails': instance.details,
+      'state':
+          _$JsonConverterToJson<Map<String, dynamic>, Map<RuleState, Since>>(
+              instance.state, const _StateJsonConverter().toJson),
     };
 
-const _$RuleStateEnumMap = {
-  RuleState.stable: 'stable',
-  RuleState.experimental: 'experimental',
-  RuleState.deprecated: 'deprecated',
-  RuleState.removed: 'removed',
-};
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) =>
+    json == null ? null : fromJson(json as Json);
 
-const _$RuleSetEnumMap = {
-  RuleSet.core: 'core',
-  RuleSet.recommended: 'recommended',
-  RuleSet.flutter: 'flutter',
-};
-
-const _$FixStatusEnumMap = {
-  FixStatus.unregistered: 'unregistered',
-  FixStatus.needsFix: 'needsFix',
-  FixStatus.needsEvaluation: 'needsEvaluation',
-  FixStatus.hasFix: 'hasFix',
-  FixStatus.noFix: 'noFix',
-};
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) =>
+    value == null ? null : toJson(value);

--- a/tools/update_lint_rules/lib/src/services/analysis_options_service.dart
+++ b/tools/update_lint_rules/lib/src/services/analysis_options_service.dart
@@ -1,6 +1,7 @@
 import 'package:file/file.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:update_lint_rules/src/extension/version_ext.dart';
 import 'package:update_lint_rules/src/models/dart_sdk_release.dart';
 import 'package:update_lint_rules/src/models/flutter_sdk_release.dart';
@@ -10,6 +11,23 @@ import 'package:update_lint_rules/src/models/recommended_rule_severity.dart';
 import 'package:update_lint_rules/src/output_dir.dart';
 
 part 'analysis_options_service.g.dart';
+
+extension ExtState on State {
+  bool hasMinimumVersion(Version version) {
+    return entries.where((e) {
+      if (e.key.inactive) {
+        return false;
+      }
+
+      final since = e.value;
+      if (since is! SinceDartSdk) {
+        return false;
+      }
+
+      return since.version <= version;
+    }).isNotEmpty;
+  }
+}
 
 @Riverpod(dependencies: [outputDir])
 AnalysisOptionsService analysisOptionsService(AnalysisOptionsServiceRef ref) {
@@ -34,28 +52,16 @@ class AnalysisOptionsService {
   }) async {
     final futures = releases.map((release) async {
       final dartSdkVersion = release.version;
-      final allLintRules = lintRules.where((lintRule) {
-        final since = lintRule.rule.since;
-        if (since is! SinceDartSdk) {
-          return false;
-        }
-        return since.version <= dartSdkVersion;
-      });
-      final filteredNotRecommendedRules = notRecommendedRules.where((r) {
-        final since = r.rule.since;
-        if (since is! SinceDartSdk) {
-          return false;
-        }
-        return since.version <= dartSdkVersion;
-      });
+      final allLintRules = lintRules.where(
+        (lintRule) =>
+            lintRule.rule.state?.hasMinimumVersion(dartSdkVersion) ?? false,
+      );
+
+      final filteredNotRecommendedRules = notRecommendedRules.where(
+        (r) => r.rule.state?.hasMinimumVersion(dartSdkVersion) ?? false,
+      );
       final filteredRecommendedRuleSeverities = recommendedRuleSeverities.where(
-        (r) {
-          final since = r.rule.since;
-          if (since is! SinceDartSdk) {
-            return false;
-          }
-          return since.version <= dartSdkVersion;
-        },
+        (r) => r.rule.state?.hasMinimumVersion(dartSdkVersion) ?? false,
       );
 
       final dartOutputDir = _outputDir
@@ -92,28 +98,15 @@ class AnalysisOptionsService {
     final futures = releases.map((release) async {
       final flutterSdkVersion = release.version;
       final dartSdkVersion = release.dartSdkVersion;
-      final allLintRules = lintRules.where((lintRule) {
-        final since = lintRule.rule.since;
-        if (since is! SinceDartSdk) {
-          return false;
-        }
-        return since.version <= dartSdkVersion;
-      });
-      final filteredNotRecommendedRules = notRecommendedRules.where((r) {
-        final since = r.rule.since;
-        if (since is! SinceDartSdk) {
-          return false;
-        }
-        return since.version <= dartSdkVersion;
-      });
+      final allLintRules = lintRules.where(
+        (lintRule) =>
+            lintRule.rule.state?.hasMinimumVersion(dartSdkVersion) ?? false,
+      );
+      final filteredNotRecommendedRules = notRecommendedRules.where(
+        (r) => r.rule.state?.hasMinimumVersion(dartSdkVersion) ?? false,
+      );
       final filteredRecommendedRuleSeverities = recommendedRuleSeverities.where(
-        (r) {
-          final since = r.rule.since;
-          if (since is! SinceDartSdk) {
-            return false;
-          }
-          return since.version <= dartSdkVersion;
-        },
+        (r) => r.rule.state?.hasMinimumVersion(dartSdkVersion) ?? false,
       );
 
       final flutterOutputDir = _outputDir
@@ -166,12 +159,24 @@ linter:
     String ruleText(Rule rule) {
       const indent = '    ';
       final buffer = StringBuffer('$indent- ${rule.name}');
-      if (rule.incompatibles case final incompatibles
-          when incompatibles.isNotEmpty) {
-        buffer.write(' # incompatibles: ${incompatibles.join(',')}');
-      }
-      if (rule.categories case final categories when categories.isNotEmpty) {
-        buffer.write(' # categories: ${categories.join(',')}');
+
+      ///  TODO:
+      ///
+      /// SHA-1: 6322a400f1b0e70cba725d857d0936b5d5e2ea99
+      ///
+      /// Comment out the property that corresponds to INCOMPATIBLE
+      /// because it does not exist in the above SHA-1.
+      ///
+      /// Deletion or not will be determined at a later date.
+
+      // if (rule.incompatibles case final incompatibles
+      //     when incompatibles.isNotEmpty) {
+      //   buffer.write(' # incompatibles: ${incompatibles.join(',')}');
+      // }
+
+      if (rule.categories case final categories
+          when categories?.isNotEmpty ?? false) {
+        buffer.write(' # categories: ${categories?.join(',')}');
       }
       return buffer.toString();
     }

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -130,13 +130,12 @@ class LintRuleService {
           final yaml = loadYaml(responseBody);
           final lintCode = Map<String, dynamic>.from(yaml['LintCode']);
 
-          // TODO: sharedNameが共通のプロパティは統合し、nameはsharedNameの値にするようにする。
-          final List<Map<String, dynamic>> json = lintCode.entries.map((e) {
-            return {
-              'name': e.key,
-              ...convertToJsonFromYaml(e.value),
-            };
-          }).toList();
+          final json = lintCode.entries
+              .where((e) => e.value['state'] != null)
+              .map((e) => {
+                    'name': e.value['sharedName'] ?? e.key,
+                    ...convertToJsonFromYaml(e.value),
+                  });
 
           final rules = json.map((e) => Rule.fromJson(e)).where((r) =>
               r.state?.keys.where((state) => state.active).isNotEmpty ?? false);


### PR DESCRIPTION
## Issue

- close #5 

## Overview (Required)
This pull request includes several changes to the `tools/update_lint_rules` package, focusing on updating the `LintRule` model, adding a new JSON converter for `State`, and modifying the `AnalysisOptionsService` to use the new `State` type. The most important changes include the introduction of the `State` type, the addition of new methods to the `RuleState` enum, and the updates to the `AnalysisOptionsService` to filter rules based on the new `State` type.

### Updates to `LintRule` model:

* Added nullable fields for `categories` and `details`, and replaced `RuleState` with the new `State` type in the `Rule` factory constructor. (`tools/update_lint_rules/lib/src/models/lint_rule.dart`, [tools/update_lint_rules/lib/src/models/lint_rule.dartL24-R25](diffhunk://#diff-49d521e806521108ca06e046c1c8217cd99b7f803ac80fc56a7dca16b6567b50L24-R25))
* Introduced the `State` type as a typedef for `Map<RuleState, Since>` and added the `_StateJsonConverter` class to handle JSON serialization and deserialization for the `State` type. (`tools/update_lint_rules/lib/src/models/lint_rule.dart`, [tools/update_lint_rules/lib/src/models/lint_rule.dartR104-R119](diffhunk://#diff-49d521e806521108ca06e046c1c8217cd99b7f803ac80fc56a7dca16b6567b50R104-R119))

### Enhancements to `RuleState` enum:

* Added `internal` state to the `RuleState` enum.
* Introduced `active` and `inactive` getter methods to determine the activity status of a rule state. (`tools/update_lint_rules/lib/src/models/lint_rule.dart`, [tools/update_lint_rules/lib/src/models/lint_rule.dartR38-R45](diffhunk://#diff-49d521e806521108ca06e046c1c8217cd99b7f803ac80fc56a7dca16b6567b50R38-R45))

### Changes to `AnalysisOptionsService`:

* Added an extension method `hasMinimumVersion` to the `State` type to check if a rule state meets a minimum Dart SDK version. (`tools/update_lint_rules/lib/src/services/analysis_options_service.dart`, [tools/update_lint_rules/lib/src/services/analysis_options_service.dartR15-R31](diffhunk://#diff-1ce84c8323842f989cdbcabbfeed19c69d2efac34c5febc888bca58e8bd749efR15-R31))
* Updated the filtering logic in `AnalysisOptionsService` to use the new `State` type and its `hasMinimumVersion` method. (`tools/update_lint_rules/lib/src/services/analysis_options_service.dart`, [tools/update_lint_rules/lib/src/services/analysis_options_service.dartL37-R64](diffhunk://#diff-1ce84c8323842f989cdbcabbfeed19c69d2efac34c5febc888bca58e8bd749efL37-R64))

### Codebase simplification:

* Removed unnecessary fields and methods related to `description`, `incompatibles`, `sets`, `fixStatus`, and `since` from the `Rule` class and its related classes and methods. (`tools/update_lint_rules/lib/src/models/lint_rule.freezed.dart`, [[1]](diffhunk://#diff-af2c7a556ef997aebc152b3aefb4cabf6f7ba587922fc3da821ffb35683aa521L393-R397) [[2]](diffhunk://#diff-af2c7a556ef997aebc152b3aefb4cabf6f7ba587922fc3da821ffb35683aa521L416-R413) [[3]](diffhunk://#diff-af2c7a556ef997aebc152b3aefb4cabf6f7ba587922fc3da821ffb35683aa521L442-L497) [[4]](diffhunk://#diff-af2c7a556ef997aebc152b3aefb4cabf6f7ba587922fc3da821ffb35683aa521L508-R465) [[5]](diffhunk://#diff-af2c7a556ef997aebc152b3aefb4cabf6f7ba587922fc3da821ffb35683aa521L531-R498) [[6]](diffhunk://#diff-af2c7a556ef997aebc152b3aefb4cabf6f7ba587922fc3da821ffb35683aa521L586-R545) [[7]](diffhunk://#diff-af2c7a556ef997aebc152b3aefb4cabf6f7ba587922fc3da821ffb35683aa521L651-R567) [[8]](diffhunk://#diff-af2c7a556ef997aebc152b3aefb4cabf6f7ba587922fc3da821ffb35683aa521L696-R603)
* Updated the JSON serialization and deserialization logic in `lint_rule.g.dart` to reflect the changes in the `Rule` class. (`tools/update_lint_rules/lib/src/models/lint_rule.g.dart`, [tools/update_lint_rules/lib/src/models/lint_rule.g.dartL17-R50](diffhunk://#diff-0aa8d21ed35df7de67ad384b8c6a403534422779c20c14d23928e59cc34db5c5L17-R50))
-

## Links

- https://github.com/dart-lang/sdk/blob/main/pkg/linter/tool/machine/rules.json
- https://github.com/dart-lang/sdk/blob/main/pkg/linter/messages.yaml

## Screenshot

N/A
