### PR TITLE
[Refactor]: Improve Lint Rule Service

### DIFF
--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -222,8 +222,8 @@ class LintRuleService {
           final allRules = [...rulesWithSharedName, ...rulesWithoutSharedName];
           return allRules
               .where((r) => r.state.keys.map((e) => e.active).contains(true))
-              .toList()
-            ..sort((a, b) => a.name.compareTo(b.name));
+              .sorted((a, b) => a.name.compareTo(b.name))
+              .toList();
         },
       );
 

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -156,29 +156,38 @@ class LintRuleService {
           final rulesWithSharedName =
               groupedLintCodeDtosBySharedName.entries.map((e) {
             final lintCodeDtosBySharedName = e.value;
-            final rule = Rule(
+            final categories = lintCodeDtosBySharedName
+                .map((e) => e.categories)
+                .nonNulls
+                .firstOrNull;
+            final details = lintCodeDtosBySharedName
+                .map((e) => e.deprecatedDetails)
+                .nonNulls
+                .firstOrNull;
+            final state = lintCodeDtosBySharedName
+                .map((e) => e.state)
+                .nonNulls
+                .firstOrNull;
+            if (categories == null || details == null || state == null) {
+              throw FormatException(
+                'Required fields are null: ${[
+                  if (categories == null) 'categories',
+                  if (details == null) 'details',
+                  if (state == null) 'state',
+                ].join(', ')}',
+              );
+            }
+            return Rule(
               name: e.key,
-              categories: lintCodeDtosBySharedName
-                  .map((e) => e.categories)
-                  .nonNulls
-                  .first,
-              details: lintCodeDtosBySharedName
-                  .map((e) => e.deprecatedDetails)
-                  .nonNulls
-                  .first,
-              state: lintCodeDtosBySharedName
-                  .map((e) => e.state)
-                  .nonNulls
-                  .first
-                  .map(
-                    (key, value) => MapEntry(
-                      RuleState.values.byName(key),
-                      Since.fromJson(value),
-                    ),
-                  ),
+              categories: categories,
+              details: details,
+              state: state.map(
+                (key, value) => MapEntry(
+                  RuleState.values.byName(key),
+                  Since.fromJson(value),
+                ),
+              ),
             );
-
-            return rule;
           });
 
           final rules = codeDtos

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -147,13 +147,13 @@ class LintRuleService {
             return LintCodeDto.fromJson(rule);
           });
 
-          final listBySharedName = codeDtos
+          final groupedLintCodeDtosBySharedName = codeDtos
               .where((dto) => dto.sharedName != null)
               // If `dto.sharedName` is not null, `dto.name` is the same as `dto.sharedName`.
               // So, group by `dto.name`.
               .groupListsBy((dto) => dto.name);
 
-          final ruleWithSharedNames = listBySharedName.entries.map((e) {
+          final ruleWithSharedNames = groupedLintCodeDtosBySharedName.entries.map((e) {
             final entryValue = e.value;
 
             final rule = Rule(

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -219,7 +219,8 @@ class LintRuleService {
             },
           );
 
-          return {...rulesWithSharedName, ...rulesWithoutSharedName}
+          final allRules = [...rulesWithSharedName, ...rulesWithoutSharedName];
+          return allRules
               .where((r) => r.state.keys.map((e) => e.active).contains(true))
               .toList()
             ..sort((a, b) => a.name.compareTo(b.name));

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -153,7 +153,8 @@ class LintRuleService {
               // So, group by `dto.name`.
               .groupListsBy((dto) => dto.name);
 
-          final ruleWithSharedNames = groupedLintCodeDtosBySharedName.entries.map((e) {
+          final rulesWithSharedName =
+              groupedLintCodeDtosBySharedName.entries.map((e) {
             final lintCodeDtosBySharedName = e.value;
             final rule = Rule(
               name: e.key,
@@ -184,7 +185,7 @@ class LintRuleService {
               .where((e) => e.canConvertToRule())
               .map((e) => Rule.fromJson(e.toJson()));
 
-          return {...ruleWithSharedNames, ...rules}
+          return {...rulesWithSharedName, ...rules}
               .where((r) => r.state.keys.map((e) => e.active).contains(true))
               .toList()
             ..sort((a, b) => a.name.compareTo(b.name));

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -154,17 +154,17 @@ class LintRuleService {
               .groupListsBy((dto) => dto.name);
 
           final ruleWithSharedNames = groupedLintCodeDtosBySharedName.entries.map((e) {
-            final entryValue = e.value;
+            final lintCodeDtosBySharedName = e.value;
 
             final rule = Rule(
               name: e.key,
-              categories: entryValue
+              categories: lintCodeDtosBySharedName
                   .firstWhere((c) => c.categories != null)
                   .categories!,
-              details: entryValue
+              details: lintCodeDtosBySharedName
                   .firstWhere((d) => d.deprecatedDetails != null)
                   .deprecatedDetails!,
-              state: entryValue.firstWhere((s) => s.state != null).state!.map(
+              state: lintCodeDtosBySharedName.firstWhere((s) => s.state != null).state!.map(
                     (key, value) => MapEntry(
                       RuleState.values.byName(key),
                       Since.fromJson(value),

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -228,8 +228,7 @@ class LintRuleService {
           // Filter out inactive rules and sort by name
           return allRules
               .where((r) => r.state.keys.map((e) => e.active).contains(true))
-              .sorted((a, b) => a.name.compareTo(b.name))
-              .toList();
+              .sorted((a, b) => a.name.compareTo(b.name));
         },
       );
 

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -155,16 +155,21 @@ class LintRuleService {
 
           final ruleWithSharedNames = groupedLintCodeDtosBySharedName.entries.map((e) {
             final lintCodeDtosBySharedName = e.value;
-
             final rule = Rule(
               name: e.key,
               categories: lintCodeDtosBySharedName
-                  .firstWhere((c) => c.categories != null)
-                  .categories!,
+                  .map((e) => e.categories)
+                  .nonNulls
+                  .first,
               details: lintCodeDtosBySharedName
-                  .firstWhere((d) => d.deprecatedDetails != null)
-                  .deprecatedDetails!,
-              state: lintCodeDtosBySharedName.firstWhere((s) => s.state != null).state!.map(
+                  .map((e) => e.deprecatedDetails)
+                  .nonNulls
+                  .first,
+              state: lintCodeDtosBySharedName
+                  .map((e) => e.state)
+                  .nonNulls
+                  .first
+                  .map(
                     (key, value) => MapEntry(
                       RuleState.values.byName(key),
                       Since.fromJson(value),

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -148,18 +148,16 @@ class LintRuleService {
           });
 
           final listBySharedName = codeDtos
-              .groupListsBy((element) => element.sharedName)
-            ..removeWhere((key, _) => key == null);
+              .where((dto) => dto.sharedName != null)
+              // If `dto.sharedName` is not null, `dto.name` is the same as `dto.sharedName`.
+              // So, group by `dto.name`.
+              .groupListsBy((dto) => dto.name);
 
           final ruleWithSharedNames = listBySharedName.entries.map((e) {
-            if (e.key == null) {
-              throw FormatException('entry.key is null: $e');
-            }
-
             final entryValue = e.value;
 
             final rule = Rule(
-              name: e.key!,
+              name: e.key,
               categories: entryValue
                   .firstWhere((c) => c.categories != null)
                   .categories!,

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -132,6 +132,7 @@ class LintRuleService {
 
           final lintCode = Map<String, dynamic>.from(yaml['LintCode']);
 
+          // Convert to DTOs
           final codeDtos = lintCode.entries.map((e) {
             final entryValue = e.value;
             if (entryValue is! YamlMap) {
@@ -147,12 +148,14 @@ class LintRuleService {
             return LintCodeDto.fromJson(rule);
           });
 
+          // Group DTOs by sharedName
           final groupedLintCodeDtosBySharedName = codeDtos
               .where((dto) => dto.sharedName != null)
               // If `dto.sharedName` is not null, `dto.name` is the same as `dto.sharedName`.
               // So, group by `dto.name`.
               .groupListsBy((dto) => dto.name);
 
+          // Convert DTOs with sharedName to Rules
           final rulesWithSharedName =
               groupedLintCodeDtosBySharedName.entries.map((e) {
             final lintCodeDtosBySharedName = e.value;
@@ -190,6 +193,7 @@ class LintRuleService {
             );
           });
 
+          // Convert DTOs without sharedName to Rules
           final rulesWithoutSharedName =
               codeDtos.where((dto) => dto.sharedName == null).map(
             (e) {
@@ -220,6 +224,8 @@ class LintRuleService {
           );
 
           final allRules = [...rulesWithSharedName, ...rulesWithoutSharedName];
+
+          // Filter out inactive rules and sort by name
           return allRules
               .where((r) => r.state.keys.map((e) => e.active).contains(true))
               .sorted((a, b) => a.name.compareTo(b.name))

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -158,16 +158,16 @@ class LintRuleService {
           // Convert DTOs with sharedName to Rules
           final rulesWithSharedName =
               groupedLintCodeDtosBySharedName.entries.map((e) {
-            final lintCodeDtosBySharedName = e.value;
-            final categories = lintCodeDtosBySharedName
+            final lintCodeDtosWithSharedName = e.value;
+            final categories = lintCodeDtosWithSharedName
                 .map((e) => e.categories)
                 .nonNulls
                 .firstOrNull;
-            final details = lintCodeDtosBySharedName
+            final details = lintCodeDtosWithSharedName
                 .map((e) => e.deprecatedDetails)
                 .nonNulls
                 .firstOrNull;
-            final state = lintCodeDtosBySharedName
+            final state = lintCodeDtosWithSharedName
                 .map((e) => e.state)
                 .nonNulls
                 .firstOrNull;


### PR DESCRIPTION
## Issue

N/A

## Overview (Required)

- Refactored the `LintRuleService` class.
- Improved the logic for converting DTOs and generating rules.

## Details

- Added processing to convert `LintCode` to DTOs.
- Improved logic to group DTOs with `sharedName` and convert them to rules.
- Added logic to convert DTOs without `sharedName` to rules.
- Added processing to filter out inactive rules and sort them by name.