### PR TITLE
feat: Add formatter section to analysis_options if Dart >= 3.8.0

### DIFF
--- a/tools/update_lint_rules/CHANGELOG.md
+++ b/tools/update_lint_rules/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Follow the [Keep a Changelog] format.
 
+## 4.1.0 - 2025-05-29
+
+### Added
+
+- Output `formatter` section in `analysis_options.yaml` for Dart 3.8.0 or later. ( `trailing_commas: preserve` )
+
 ## 4.0.0 - 2025-04-22
 
 ### Changed

--- a/tools/update_lint_rules/lib/src/services/analysis_options_service.dart
+++ b/tools/update_lint_rules/lib/src/services/analysis_options_service.dart
@@ -1,5 +1,6 @@
 import 'package:file/file.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:update_lint_rules/src/extension/version_ext.dart';
@@ -55,11 +56,14 @@ class AnalysisOptionsService {
         ..createSync(recursive: true);
       final recommendedIncludeContent =
           'include: package:yumemi_lints/dart/${dartSdkVersion.excludePatchVersion}/all.yaml';
+      final formatterContent =
+          dartSdkVersion < Version(3, 8, 0) ? null : _formatterContent;
       return outputRecommendedLintRules(
         outputFile: recommendedFile,
         notRecommendedRules: filteredNotRecommendedRules,
         recommendedRuleSeverities: filteredRecommendedRuleSeverities,
         includeContent: recommendedIncludeContent,
+        formatterContent: formatterContent,
       );
     });
 
@@ -103,11 +107,14 @@ class AnalysisOptionsService {
         ..createSync(recursive: true);
       final recommendedIncludeContent =
           'include: package:yumemi_lints/flutter/${flutterSdkVersion.excludePatchVersion}/all.yaml';
+      final formatterContent =
+          dartSdkVersion < Version(3, 8, 0) ? null : _formatterContent;
       return outputRecommendedLintRules(
         outputFile: recommendedFile,
         notRecommendedRules: filteredNotRecommendedRules,
         recommendedRuleSeverities: filteredRecommendedRuleSeverities,
         includeContent: recommendedIncludeContent,
+        formatterContent: formatterContent,
       );
     });
 
@@ -168,6 +175,7 @@ linter:
     required Iterable<NotRecommendedRule> notRecommendedRules,
     required Iterable<RecommendedRuleSeverity> recommendedRuleSeverities,
     required String includeContent,
+    required String? formatterContent,
   }) async {
     final contentBuffer = StringBuffer();
     contentBuffer.writeln(_headerContent);
@@ -189,6 +197,10 @@ linter:
         .join('\n\n');
     contentBuffer.writeln(recommendedRuleSeveritiesTexts);
     contentBuffer.writeln();
+
+    if (formatterContent != null) {
+      contentBuffer.writeln(formatterContent);
+    }
 
     contentBuffer.writeln('''
 linter:
@@ -222,4 +234,9 @@ analyzer:
 
     # Members annotated with `visibleForTesting` should not be referenced outside of the library in which they are declared or libraries within the test directory.
     invalid_use_of_visible_for_testing_member: error
+''';
+
+const _formatterContent = '''
+formatter:
+  trailing_commas: preserve
 ''';

--- a/tools/update_lint_rules/lib/src/services/analysis_options_service.dart
+++ b/tools/update_lint_rules/lib/src/services/analysis_options_service.dart
@@ -170,26 +170,13 @@ linter:
     required String includeContent,
   }) async {
     final contentBuffer = StringBuffer();
-    contentBuffer.writeln('# GENERATED CODE - DO NOT MODIFY BY HAND');
+    contentBuffer.writeln(_headerContent);
     contentBuffer.writeln();
 
     contentBuffer.writeln(includeContent);
     contentBuffer.writeln();
 
-    contentBuffer.writeln('''
-analyzer:
-  language:
-    # Increase safety as much as possible.
-    strict-casts: true
-    strict-inference: true
-    strict-raw-types: true
-  errors:
-    # By including all.yaml, some rules will conflict. These warnings will be addressed within this file.
-    included_file_warning: ignore
-
-    # Members annotated with `visibleForTesting` should not be referenced outside of the library in which they are declared or libraries within the test directory.
-    invalid_use_of_visible_for_testing_member: error
-''');
+    contentBuffer.writeln(_analyzerContent);
 
     const indent = '    ';
     final recommendedRuleSeveritiesTexts = recommendedRuleSeverities
@@ -219,3 +206,20 @@ linter:
     outputFile.writeAsStringSync(contentBuffer.toString());
   }
 }
+
+const _headerContent = '# GENERATED CODE - DO NOT MODIFY BY HAND';
+
+const _analyzerContent = '''
+analyzer:
+  language:
+    # Increase safety as much as possible.
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+  errors:
+    # By including all.yaml, some rules will conflict. These warnings will be addressed within this file.
+    included_file_warning: ignore
+
+    # Members annotated with `visibleForTesting` should not be referenced outside of the library in which they are declared or libraries within the test directory.
+    invalid_use_of_visible_for_testing_member: error
+''';

--- a/tools/update_lint_rules/pubspec.yaml
+++ b/tools/update_lint_rules/pubspec.yaml
@@ -1,6 +1,6 @@
 name: update_lint_rules
 description: A sample command-line application.
-version: 4.0.0
+version: 4.1.0
 # repository: https://github.com/my_org/my_repo
 
 environment:

--- a/tools/update_lint_rules/test/fakes/services/fake_analysis_options_service.dart
+++ b/tools/update_lint_rules/test/fakes/services/fake_analysis_options_service.dart
@@ -36,5 +36,6 @@ class FakeAnalysisOptionsService implements AnalysisOptionsService {
     required Iterable<NotRecommendedRule> notRecommendedRules,
     required Iterable<RecommendedRuleSeverity> recommendedRuleSeverities,
     required String includeContent,
+    required String? formatterContent,
   }) async {}
 }


### PR DESCRIPTION
## Issue

- close #17 

## Overview (Required)

- Output formatter config for Dart 3.8.0 or later in analysis_options
- Define header, analyzer, and formatter content as constants for better readability

## Links

-

## Screenshot

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |